### PR TITLE
Adiciona checagem do arquivo de configuração SSH

### DIFF
--- a/ssh-connect.py
+++ b/ssh-connect.py
@@ -10,6 +10,10 @@ from collections import defaultdict
 
 SSH_CONFIG_PATH = os.path.expanduser("~/.ssh/config")
 
+if not os.path.exists(SSH_CONFIG_PATH):
+    print(f"Config file does not exist: {SSH_CONFIG_PATH}")
+    sys.exit(1)
+
 def listar_hosts_ssh():
     """Lê ~/.ssh/config e retorna uma lista de hosts e seus detalhes, incluindo comentários."""
     config_data = defaultdict(dict)


### PR DESCRIPTION
### O que foi feito?
Adiciona uma checagem para garantir que o arquivo de configuração SSH (~/.ssh/config) existe antes de prosseguir. Caso contrário, o programa encerra com um erro.

### Por quê?
Essa alteração evita erros em ambientes onde o arquivo de configuração SSH não está presente, garantindo que o programa falhe de forma controlada.

### Como foi implementado?
Foi adicionada uma verificação usando `os.path.exists` para checar a existência do arquivo. Caso o arquivo não exista, uma mensagem de erro é exibida e o programa é encerrado com `sys.exit(1)`.